### PR TITLE
Fix broken zesty redirect; make direct API request

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ A [Hubot](https://github.com/github/hubot) plugin to tell you what Zesty is cate
 
 #### Configuration
 
-You'll need to add a `HUBOT_ZESTY_ACCOUNT_NAME` variable into your environment with the value being that that exists in your Zesty menu URL: `www.zesty.com/account-name`
+You'll need to add a `HUBOT_ZESTY_ACCOUNT_ID` variable into your environment with the value being your Zesty client ID found in your dashboard URL.
 
 #### Heroku
 
-    % heroku config:add HUBOT_ZESTY_ACCOUNT_NAME="your-zesty-account-name"
+    % heroku config:add HUBOT_ZESTY_ACCOUNT_ID="your-zesty-account-ID"
 
 #### Non-Heroku environment variables
 
-    % export HUBOT_ZESTY_ACCOUNT_NAME="your-zesty-account-name"
+    % export HUBOT_ZESTY_ACCOUNT_ID="your-zesty-account-ID"
 
 ### Installation
 1. Edit `package.json` and add `hubot-zesty` as a dependency.

--- a/src/zesty.coffee
+++ b/src/zesty.coffee
@@ -6,7 +6,7 @@
 #   "moment": "2.0.x"
 #
 # Configuration:
-#   HUBOT_ZESTY_ACCOUNT_NAME - In the format of http://zesty.com/ACCOUNT_NAME
+#   HUBOT_ZESTY_ACCOUNT_ID - Account ID found in the URL of your client dashboard
 #
 # Commands:
 #   hubot zesty - Pulls your catering menu for today
@@ -65,57 +65,47 @@ getCatering = (msg, date) ->
     return msg.send 'I don\'t know when that is.'
 
   searchDate = date.format('YYYY-MM-DD')
-
-  request 'http://zesty.com/' + process.env.HUBOT_ZESTY_ACCOUNT_NAME, (err, res, body) =>
-    return msg.send "Unable to pull your Zesty ID. ERROR: #{err}" if err
-    return msg.send "Unable to pull your Zesty ID. ERROR: #{res.statusCode + ':\n' + body}" if res.statusCode != 200
-
-    resUrl = url.parse(res.request.uri.href);
-    if resUrl.host != 'catering.zesty.com'
-      return msg.send "Sorry, Zesty took us to an unexpected domain: #{resUrl.host}."
-
-    accountId = resUrl.hash.replace(/#\//, '')
-
-    options = {
-      url: 'https://api.hastyapp.com/catering_clients/' + accountId,
-      followAllRedirects: true,
-      headers: {
-        'Accept': 'application/json; version=2'
-        'X-HASTY-API-KEY': '7f2e945f9eef4527ee6aa2be0a130718',
-        'User-Agent': 'hubot-zesty (http://github.com/jonursenbach/hubot-zesty)'
-      }
+  accountId = process.env.HUBOT_ZESTY_ACCOUNT_ID
+  options = {
+    url: 'https://api.hastyapp.com/catering_clients/' + accountId,
+    followAllRedirects: true,
+    headers: {
+      'Accept': 'application/json; version=2'
+      'X-HASTY-API-KEY': '7f2e945f9eef4527ee6aa2be0a130718',
+      'User-Agent': 'hubot-zesty (http://github.com/jonursenbach/hubot-zesty)'
     }
+  }
 
-    request options, (err, res, body) =>
-      return msg.send "Unable to pull your menu. ERROR: #{err}" if err
-      return msg.send "Unable to pull your menu. ERROR: #{res.statusCode + ':\n' + body}" if res.statusCode != 200
+  request options, (err, res, body) =>
+    return msg.send "Unable to pull your menu. ERROR: #{err}" if err
+    return msg.send "Unable to pull your menu. ERROR: #{res.statusCode + ':\n' + body}" if res.statusCode != 200
 
-      catering = JSON.parse(body)
+    catering = JSON.parse(body)
 
-      for order in catering.catering_orders
-        if order.delivery_date.indexOf(searchDate) != -1
-          emit = 'Catering for ' + searchDate + ' is coming from ' + order.restaurant_name + '.\n\n';
+    for order in catering.catering_orders
+      if order.delivery_date.indexOf(searchDate) != -1
+        emit = 'Catering for ' + searchDate + ' is coming from ' + order.restaurant_name + '.\n\n';
 
-          items = order.catering_order_items
+        items = order.catering_order_items
 
-          for item in catering.catering_order_items
-            if items.indexOf(item.id) != -1
-              for dish in catering.dishes
-                if dish.id == item.dish
-                  dishName = dish.name.trim()
+        for item in catering.catering_order_items
+          if items.indexOf(item.id) != -1
+            for dish in catering.dishes
+              if dish.id == item.dish
+                dishName = dish.name.trim()
 
-                  modifiers = getDishModifiers(dish)
-                  if modifiers.length > 0
-                    emit += dishName + ' (' + modifiers.join(', ') + ')\n'
-                  else
-                    emit += dishName + '\n'
+                modifiers = getDishModifiers(dish)
+                if modifiers.length > 0
+                  emit += dishName + ' (' + modifiers.join(', ') + ')\n'
+                else
+                  emit += dishName + '\n'
 
-                  if dish.description != ''
-                    emit += ' - ' + dish.description + '\n'
+                if dish.description != ''
+                  emit += ' - ' + dish.description + '\n'
 
-                  emit += '\n'
+                emit += '\n'
 
-          msg.send emit
-          return
+        msg.send emit
+        return
 
-      msg.send "Sorry, I was unable to find a menu for #{searchDate}."
+    msg.send "Sorry, I was unable to find a menu for #{searchDate}."


### PR DESCRIPTION
Zesty continues to change things. The initial request to `zesty.com` doesn't work anymore. Changing it to be direct to the API using the client ID.

I think the old API will be discontinued soon as well.
